### PR TITLE
269 - Bugfix: Allow elements to 'unstick'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampersandhq/react-sticky",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampersandhq/react-sticky",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Sticky component for React",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -73,7 +73,10 @@ export default class Sticky extends Component {
         const { isSticky } = this.state;
 
         if (!setAsSticky) {
-            return null;
+            return this.setState({
+                isSticky: false,
+                style: {},
+            });
         }
 
         let preventingStickyStateChanges = false;


### PR DESCRIPTION
If an element has `setAsSticky` set to `false` somehow (e.g. scrolling down means it shouldn't stick), then ensure the state is set to remove the `sticky` prop and the styles to prevent the element from remaining stuck in place. 

![Demo recording](https://recordit.co/ydvG6rXDWb/gif/notify)